### PR TITLE
Download redis from download.redis.io

### DIFF
--- a/dockyard
+++ b/dockyard
@@ -162,7 +162,7 @@ function apply_nginx_syslog_patch {
 function install_nginx {
   url="http://nginx.org/download/nginx-$version.tar.gz"
   required_packages="unzip libpcre3 libpcre3-dev libssl-dev libpcrecpp0 zlib1g-dev libgd2-xpm-dev"
-  configure_cmd="./configure --with-http_ssl_module --with-http_spdy_module --with-http_gzip_static_module --with-http_stub_status_module --add-module=/tmp/nginx_syslog_patch"
+  configure_cmd="./configure --with-http_ssl_module --with-http_spdy_module --with-http_gzip_static_module --with-http_stub_status_module"
   download_url $url
   install_required_packages
   extract

--- a/dockyard
+++ b/dockyard
@@ -166,7 +166,7 @@ function install_nginx {
   download_url $url
   install_required_packages
   extract
-  apply_nginx_syslog_patch
+  # apply_nginx_syslog_patch
   configure
   build
   install_binaries

--- a/dockyard
+++ b/dockyard
@@ -187,7 +187,7 @@ function install_ruby {
 }
 
 function install_redis {
-  url=http://redis.googlecode.com/files/redis-$version.tar.gz
+  url=http://download.redis.io/releases/redis-$version.tar.gz
   download_url $url
   extract
   build


### PR DESCRIPTION
It seems redis downloads have been moved to redis.io meanwhile
